### PR TITLE
DTSPO-10841 - remove az cmd from pipeline and update instructions on running it manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,24 @@ The service connection names can only contain letters, numbers and underscores.
 
 The pipeline parameters for environment and product will be computed based on the name of the subscription.
 
-When adding a new subscription you need to make the Service Principal of the new subscription the owner of the DTS Public DNS Contributor (env:ENVIRONMENT) group.
+When adding a new subscription you need to make the Service Principal of the new subscription `DTS Bootstrap (sub:SUBSCRIPTION_NAME)` the owner of the `DTS Public DNS Contributor (env:ENVIRONMENT)` group.
 
-Update the script in scripts/dnsgroupowner.sh with the correct ENVIRONMENT and SUBSCRIPTION,  Uncomment the Add_ownership_to_DNS_groups Stage and change the dependsOn in Stage ${{ deployment.stage }}_acme to 'Add_ownership_to_DNS_groups' on the azure-pipeline.yml.
+To grant yourself permissions:
+Go to the [PIM settings](https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/CommonMenuBlade/quickStart).
 
-Once the pipeline has ran and added the ownership to the group you need to comment out Add_ownership_to_DNS_groups Stage and change the dependsOn in Stage ${{ deployment.stage }}_acme to Precheck.
+Click on My roles under tasks in the left hand side. Select Group Administrator and select activate. Then submit your request for elevated permissions. Once that is complete you will be able to run the command below successfully. 
+
+Edit and run the command below, replacing ENVIRONMENT_NAME with the environment name and SUBSCRIPTION_NAME with the subscription name.
+
+```shell
+az ad group owner add --group "DTS Public DNS Contributor (env:ENVIRONMENT_NAME)" --owner-object-id $(az ad sp list --display-name "DTS Bootstrap (sub:SUBSCRIPTION_NAME)" --query '[].{id:id}' -o tsv)
+```
+
+For example if you wanted to make `DTS Bootstrap (sub:dcd-cftapps-sbox)` a group owner of the `DTS Public DNS Contributor (env:sbox)` group you would run the following command:
+
+```shell
+az ad group owner add --group "DTS Public DNS Contributor (env:sbox)" --owner-object-id $(az ad sp list --display-name "DTS Bootstrap (sub:dcd-cftapps-sbox)" --query '[].{id:id}' -o tsv)
+```
 
 ## Importing an existing subscription
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ The pipeline parameters for environment and product will be computed based on th
 
 When adding a new subscription you need to make the Service Principal of the new subscription `DTS Bootstrap (sub:SUBSCRIPTION_NAME)` the owner of the `DTS Public DNS Contributor (env:ENVIRONMENT)` group.
 
-To grant yourself permissions:
-Go to the [PIM settings](https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/CommonMenuBlade/quickStart).
+Elevate your permissions by going to the [PIM settings](https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/CommonMenuBlade/quickStart).
 
 Click on My roles under tasks in the left hand side. Select Group Administrator and select activate. Then submit your request for elevated permissions. Once that is complete you will be able to run the command below successfully. 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The service connection names can only contain letters, numbers and underscores.
 
 The pipeline parameters for environment and product will be computed based on the name of the subscription.
 
+When adding a new subscription you need to make the Service Principal of the new subscription the owner of the DTS Public DNS Contributor (env:ENVIRONMENT) group.
+
+Update the script in scripts/dnsgroupowner.sh with the correct ENVIRONMENT and SUBSCRIPTION,  Uncomment the Add_ownership_to_DNS_groups Stage and change the dependsOn in Stage ${{ deployment.stage }}_acme to 'Add_ownership_to_DNS_groups' on the azure-pipeline.yml.
+
+Once the pipeline has ran and added the ownership to the group you need to comment out Add_ownership_to_DNS_groups Stage and change the dependsOn in Stage ${{ deployment.stage }}_acme to Precheck.
+
 ## Importing an existing subscription
 
 1. Ensure you have azure-cli installed and logged in as well as terraform and jq.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,23 +118,23 @@ stages:
               serviceConnection: 'DCD-CFT-Sandbox'
 
 
-  - stage: 'Add_ownership_to_DNS_groups'
-    jobs:
-      - job:
-        pool:
-          vmImage: ${{ variables.agentPool }}
-        steps:
-          - task: AzureCLI@2
-            continueOnError: true
-            inputs:
-              azureSubscription: 'GA'
-              scriptType: 'bash'
-              scriptLocation: 'scriptPath'
-              scriptPath: 'scripts/dnsgroupowner.sh'
+#   - stage: 'Add_ownership_to_DNS_groups'
+#     jobs:
+#       - job:
+#         pool:
+#           vmImage: ${{ variables.agentPool }}
+#         steps:
+#           - task: AzureCLI@2
+#             continueOnError: true
+#             inputs:
+#               azureSubscription: 'GA'
+#               scriptType: 'bash'
+#               scriptLocation: 'scriptPath'
+#               scriptPath: 'scripts/dnsgroupowner.sh'
 
   - ${{ each deployment in parameters.environment_components }}:
       - stage: "${{ deployment.stage }}_acme"
-        dependsOn: 'Add_ownership_to_DNS_groups'
+        dependsOn: 'Precheck'
         jobs:
           - job: TerraformPlanApply
             pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,19 +118,6 @@ stages:
               serviceConnection: 'DCD-CFT-Sandbox'
 
 
-#   - stage: 'Add_ownership_to_DNS_groups'
-#     jobs:
-#       - job:
-#         pool:
-#           vmImage: ${{ variables.agentPool }}
-#         steps:
-#           - task: AzureCLI@2
-#             continueOnError: true
-#             inputs:
-#               azureSubscription: 'GA'
-#               scriptType: 'bash'
-#               scriptLocation: 'scriptPath'
-#               scriptPath: 'scripts/dnsgroupowner.sh'
 
   - ${{ each deployment in parameters.environment_components }}:
       - stage: "${{ deployment.stage }}_acme"

--- a/scripts/dnsgroupowner.sh
+++ b/scripts/dnsgroupowner.sh
@@ -1,1 +1,0 @@
-az ad group owner add --group "DTS Public DNS Contributor (env:sbox)" --owner-object-id $(az ad sp list --display-name "DTS Bootstrap (sub:dcd-cftapps-sbox)" --query '[].{id:id}' -o tsv)


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-10841](https://tools.hmcts.net/jira/browse/DTSPO-10841)

### Change description ###
We've removed the az cli command from the pipeline as it's showing as a warning in the pipeline and shouldn't be needed to be done very often. 

Ideally this would be managed in code and we may want to do that if we add more subscriptions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
