### PR TITLE
Allow sps bootstrap to create rbac on acme vault for KV read

### DIFF
--- a/components/acme/data.tf
+++ b/components/acme/data.tf
@@ -30,3 +30,8 @@ data "azuread_group" "dns_contributor_groups" {
 data "azuread_service_principal" "app_proxy_ga_service_connection" {
   display_name = "DTS Operations Bootstrap GA"
 }
+
+data "azuread_service_principal" "kv_rbac_admin" {
+  for_each     = var.kv_rbac_admin_service_principals
+  display_name = each.value
+}

--- a/components/acme/managedidentity.tf
+++ b/components/acme/managedidentity.tf
@@ -28,3 +28,10 @@ resource "azurerm_role_assignment" "app-proxy-ga-service-connection-certificate-
   role_definition_name = "Key Vault Secrets User"
   scope                = azurerm_key_vault.kv.id
 }
+
+resource "azurerm_role_assignment" "kv-rbac-admin" {
+  for_each             = var.product == "cft-platform" ? var.kv_rbac_admin_service_principals : toset([])
+  principal_id         = data.azuread_service_principal.kv_rbac_admin[each.key].object_id
+  role_definition_name = "Role Based Access Control Administrator"
+  scope                = azurerm_key_vault.kv.id
+}

--- a/components/acme/variables.tf
+++ b/components/acme/variables.tf
@@ -45,6 +45,12 @@ variable "additional_dns_contributor_envs" {
   default = []
 }
 
+variable "kv_rbac_admin_service_principals" {
+  description = "Service principal display names to grant Role Based Access Control Administrator on the ACME Key Vault"
+  type        = set(string)
+  default     = []
+}
+
 variable "acme_version" {
   description = "Version of keyvault-acmebot to deploy. Must be in the form vMAJOR.MINOR.PATCH (e.g. v4.3.1). Renovate automatically creates PRs for new releases from https://github.com/shibayan/keyvault-acmebot/releases"
   type        = string

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -1,0 +1,1 @@
+kv_rbac_admin_service_principals = ["DTS Bootstrap (sub:dts-sps-sbox)"]


### PR DESCRIPTION
Unblocks https://github.com/hmcts/platform-ai-gateway-infra/pull/2

Done this way around so that UAMI + Permission lifecycle is entirely managed from new [platform-ai-gateway-infra](https://github.com/hmcts/platform-ai-gateway-infra) repo - it creates the UAMI, and required role assignments to function in one place.

This change:

- allows us to give the name of the app registration building the ai gateway terraform, gives it permission to add RBAC assignments **only** to the acme key vault

This is required to allow the above PR to perform a terraform apply, so that we can give the APIM managed identity access to the ACME Key Vault, by assigning Key Vault Secrets User on the ACME vault


> [!NOTE]
> There is an SPS acme key vault made in this repo, but it includes a different wildcard cert `wildcard-sandbox-api-hmcts-net` - we'd have to import the `wildcard-platform-hmcts-net` cert and manage it twice, so it makes more sense to give access on the existing